### PR TITLE
add min id to metadata

### DIFF
--- a/stns/config.go
+++ b/stns/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	Sudoers    Attributes
 }
 
+var MinUserId, MinGroupId int
+
 func LoadConfig(configFile string) (Config, error) {
 	var config Config
 	defaultConfig(&config)
@@ -34,6 +36,8 @@ func LoadConfig(configFile string) (Config, error) {
 			return Config{}, err
 		}
 	}
+	setIdRange(&MinUserId, config.Users)
+	setIdRange(&MinGroupId, config.Groups)
 	return config, nil
 }
 
@@ -42,6 +46,21 @@ func defaultConfig(config *Config) {
 	config.Salt = false
 	config.Stretching = 0
 	config.HashType = "sha256"
+}
+
+func setIdRange(min *int, attrs Attributes) {
+	if len(attrs) > 0 {
+
+		for _, a := range attrs {
+			switch {
+
+			case *min == 0:
+				*min = a.Id
+			case *min > a.Id:
+				*min = a.Id
+			}
+		}
+	}
 }
 
 func includeConfigFile(config *Config, include string) error {

--- a/stns/config_test.go
+++ b/stns/config_test.go
@@ -24,6 +24,11 @@ func TestLoadConfig(t *testing.T) {
 	assert(t, config.Sudoers["example"].Password == "p@ssword", "unmatch password")
 }
 
+func TestMinId(t *testing.T) {
+	LoadConfig("./fixtures/min_id.conf")
+	assert(t, MinUserId == 1, "unmatch min user")
+	assert(t, MinGroupId == 3, "unmatch min group")
+}
 func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Error(err)

--- a/stns/fixtures/min_id.conf
+++ b/stns/fixtures/min_id.conf
@@ -1,0 +1,14 @@
+port = 9999
+salt_enable = true
+stretching_number = 1000
+hash_type = "sha256"
+[users.example1]
+id = 1
+[users.example2]
+id = 2
+
+[groups.example1]
+id = 3
+
+[groups.example2]
+id = 4

--- a/stns/handler.go
+++ b/stns/handler.go
@@ -18,6 +18,7 @@ type MetaData struct {
 	Stretching int     `json:"stretching_number"`
 	HashType   string  `json:"hash_type"`
 	Result     string  `json:"result""`
+	MinId      int     `json:"min_id""`
 }
 
 type ResponseFormat struct {
@@ -63,6 +64,7 @@ func (h *Handler) Response(q *Query, w rest.ResponseWriter, r *rest.Request) {
 				Stretching: h.config.Stretching,
 				Result:     settings.SUCCESS,
 				HashType:   h.config.HashType,
+				MinId:      q.GetMinId(),
 			},
 			Items: &attr,
 		}

--- a/stns/query.go
+++ b/stns/query.go
@@ -20,6 +20,15 @@ func (q *Query) getConfigByType() Attributes {
 	return nil
 }
 
+func (q *Query) GetMinId() int {
+	if q.resource == "user" {
+		return MinUserId
+	} else if q.resource == "group" {
+		return MinGroupId
+	}
+	return 0
+}
+
 func (q *Query) getAttribute() Attributes {
 	resource := q.getConfigByType()
 	if resource != nil && !reflect.ValueOf(resource).IsNil() {

--- a/stns/stns_test.go
+++ b/stns/stns_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ant0ine/go-json-rest/rest/test"
 )
 
-func TestHandlerV1(t *testing.T) {
+func TestHandlerV1User(t *testing.T) {
 	config, _ := LoadConfig("./fixtures/stns_01.conf")
 	s := Create(config, "", "")
 
@@ -52,8 +52,12 @@ func TestHandlerV1(t *testing.T) {
 }`)
 	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/user/id/1001", nil))
 	recorded.CodeIs(404)
+}
+func TestHandlerV1Group(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "")
 
-	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/group/name/example_group", nil))
+	recorded := test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/group/name/example_group", nil))
 	recorded.CodeIs(200)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs(`{
@@ -83,8 +87,12 @@ func TestHandlerV1(t *testing.T) {
 
 	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/group/id/3001", nil))
 	recorded.CodeIs(404)
+}
+func TestHandlerV1Sudo(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "")
 
-	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/sudo/name/example_sudo", nil))
+	recorded := test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/sudo/name/example_sudo", nil))
 	recorded.CodeIs(200)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs(`{
@@ -108,7 +116,7 @@ func TestHandlerV1(t *testing.T) {
 	recorded.CodeIs(404)
 }
 
-func TestHandlerV2(t *testing.T) {
+func TestHandlerV2User(t *testing.T) {
 	config, _ := LoadConfig("./fixtures/stns_01.conf")
 	s := Create(config, "", "")
 
@@ -121,7 +129,8 @@ func TestHandlerV2(t *testing.T) {
     "salt_enable": false,
     "stretching_number": 0,
     "hash_type": "sha256",
-    "result": "success"
+    "result": "success",
+    "min_id": 1000
   },
   "items": {
     "example": {
@@ -151,7 +160,8 @@ func TestHandlerV2(t *testing.T) {
     "salt_enable": false,
     "stretching_number": 0,
     "hash_type": "sha256",
-    "result": "success"
+    "result": "success",
+    "min_id": 1000
   },
   "items": {
     "example": {
@@ -171,8 +181,12 @@ func TestHandlerV2(t *testing.T) {
 }`)
 	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/user/id/1001", nil))
 	recorded.CodeIs(404)
+}
+func TestHandlerV2Group(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "")
 
-	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/group/name/example_group", nil))
+	recorded := test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/group/name/example_group", nil))
 	recorded.CodeIs(200)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs(`{
@@ -181,7 +195,8 @@ func TestHandlerV2(t *testing.T) {
     "salt_enable": false,
     "stretching_number": 0,
     "hash_type": "sha256",
-    "result": "success"
+    "result": "success",
+    "min_id": 3000
   },
   "items": {
     "example_group": {
@@ -205,7 +220,8 @@ func TestHandlerV2(t *testing.T) {
     "salt_enable": false,
     "stretching_number": 0,
     "hash_type": "sha256",
-    "result": "success"
+    "result": "success",
+    "min_id": 3000
   },
   "items": {
     "example_group": {
@@ -220,8 +236,12 @@ func TestHandlerV2(t *testing.T) {
 
 	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/group/id/3001", nil))
 	recorded.CodeIs(404)
+}
+func TestHandlerV2Sudo(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "")
 
-	recorded = test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/sudo/name/example_sudo", nil))
+	recorded := test.RunRequest(t, s.Handler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/sudo/name/example_sudo", nil))
 	recorded.CodeIs(200)
 	recorded.ContentTypeIsJson()
 	recorded.BodyIs(`{
@@ -230,7 +250,8 @@ func TestHandlerV2(t *testing.T) {
     "salt_enable": false,
     "stretching_number": 0,
     "hash_type": "sha256",
-    "result": "success"
+    "result": "success",
+    "min_id": 0
   },
   "items": {
     "example_sudo": {


### PR DESCRIPTION
And to contain minimal id into the metadata of the api
```
% curl http://localhost:1104/v2/user/name/pyama
{
  "metadata": {
    "api_version": 2,
    "salt_enable": false,
    "stretching_number": 0,
    "hash_type": "sha256",
    "result": "success",
    "min_id": 1001 ⇐ new column
  },
  "items": {
    "pyama": {
      "id": 1001,
      "password": "test",
      "hash_type": "",
      "group_id": 1001,
      "directory": "/home/pyama",
      "shell": "/bin/sh",
      "gecos": "pyama",
      "keys": [
        "ssh-rsa xxxx"
      ],
      "link_users": null
    }
  }
}
```