### PR TITLE
より汎用的なフォーマットv3Apiを追加します。

### DIFF
--- a/stns/handler.go
+++ b/stns/handler.go
@@ -1,25 +1,9 @@
 package stns
 
-import (
-	"net/http"
-
-	"github.com/STNS/STNS/settings"
-	"github.com/ant0ine/go-json-rest/rest"
-)
+import "github.com/ant0ine/go-json-rest/rest"
 
 type Handler struct {
 	config *Config
-}
-
-type MetaData struct {
-	ApiVersion float64 `json:"api_version"`
-	Result     string  `json:"result""`
-	MinId      int     `json:"min_id""`
-}
-
-type ResponseFormat struct {
-	MetaData *MetaData  `json:"metadata"`
-	Items    Attributes `json:"items"`
 }
 
 func (h *Handler) getQuery(r *rest.Request) *Query {
@@ -45,27 +29,6 @@ func (h *Handler) GetList(w rest.ResponseWriter, r *rest.Request) {
 }
 
 func (h *Handler) Response(q *Query, w rest.ResponseWriter, r *rest.Request) {
-	attr := q.Get()
-	if r.URL.Path[1:3] == "v2" {
-		if attr == nil {
-			w.WriteHeader(http.StatusNotFound)
-		}
-		response := ResponseFormat{
-			MetaData: &MetaData{
-				ApiVersion: settings.API_VERSION,
-				Result:     settings.SUCCESS,
-				MinId:      q.GetMinId(),
-			},
-			Items: attr,
-		}
-		w.WriteJson(response)
-		return
-	} else {
-		if attr == nil {
-			rest.NotFound(w, r)
-		} else {
-			w.WriteJson(attr)
-		}
-		return
-	}
+	res := NewResponder(q, w, r)
+	res.Response()
 }

--- a/stns/pid.go
+++ b/stns/pid.go
@@ -31,6 +31,6 @@ func createPidFile(pidFile string) error {
 
 func removePidFile(pidFile string) {
 	if err := os.Remove(pidFile); err != nil {
-		log.Fatal("Error removing %s: %s", pidFile, err)
+		log.Fatalf("Error removing %s: %s", pidFile, err)
 	}
 }

--- a/stns/responder.go
+++ b/stns/responder.go
@@ -1,0 +1,217 @@
+package stns
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/STNS/STNS/settings"
+	"github.com/ant0ine/go-json-rest/rest"
+)
+
+type responser interface {
+	Response()
+}
+
+// ----------------------------------------
+// v1
+// ----------------------------------------
+type v1_ResponseFormat struct {
+	Items Attributes `json:"items"`
+	query *Query
+	w     rest.ResponseWriter
+	r     *rest.Request
+}
+
+func (self *v1_ResponseFormat) Response() {
+	if self.Items == nil {
+		rest.NotFound(self.w, self.r)
+	} else {
+		self.w.WriteJson(self.Items)
+	}
+}
+
+// ----------------------------------------
+// v2
+// ----------------------------------------
+type v2_MetaData struct {
+	ApiVersion float64 `json:"api_version"`
+	Result     string  `json:"result""`
+	MinId      int     `json:"min_id""`
+}
+
+type v2_ResponseFormat struct {
+	MetaData *v2_MetaData `json:"metadata"`
+	Items    Attributes   `json:"items"`
+	query    *Query
+	w        rest.ResponseWriter
+	r        *rest.Request
+}
+
+func (self *v2_ResponseFormat) Response() {
+	if self.Items == nil {
+		self.w.WriteHeader(http.StatusNotFound)
+	}
+
+	response := v2_ResponseFormat{
+		MetaData: &v2_MetaData{
+			ApiVersion: settings.API_VERSION,
+			Result:     settings.SUCCESS,
+			MinId:      self.query.GetMinId(),
+		},
+		Items: self.Items,
+	}
+	self.w.WriteJson(response)
+	return
+}
+
+// ----------------------------------------
+// v3
+// ----------------------------------------
+type v3_ResponseFormat struct {
+	Items Attributes `json:"items"`
+	query *Query
+	w     rest.ResponseWriter
+	r     *rest.Request
+}
+
+type v3User struct {
+	Id        int      `json:"id"`
+	Name      string   `json:"name"`
+	Password  string   `json:"password"`
+	GroupId   int      `json:"group_id"`
+	Directory string   `json:"directory"`
+	Shell     string   `json:"shell"`
+	Gecos     string   `json:"gecos"`
+	Keys      []string `json:"keys"`
+}
+
+type v3Group struct {
+	Id    int      `json:"id"`
+	Name  string   `json:"name"`
+	Users []string `json:"users"`
+}
+
+type v3Sudo struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+type v3Users struct {
+	items []*v3User
+}
+type v3Groups struct {
+	items []*v3Group
+}
+
+type v3Sudoers struct {
+	items []*v3Sudo
+}
+
+type v3Resource interface {
+	buildResource(string, *Attribute) interface{}
+}
+
+func NewV3Resource(q *Query) v3Resource {
+	switch q.resource {
+	case "user":
+		return v3Users{}
+	case "group":
+		return v3Groups{}
+	case "sudo":
+		return v3Sudoers{}
+	}
+	return nil
+}
+
+func (self v3Users) buildResource(n string, u *Attribute) interface{} {
+	if u.User != nil {
+		return &v3User{
+			Name:      n,
+			Id:        u.Id,
+			Password:  u.Password,
+			GroupId:   u.GroupId,
+			Directory: u.Directory,
+			Shell:     u.Shell,
+			Gecos:     u.Gecos,
+			Keys:      u.Keys,
+		}
+	}
+	return nil
+}
+
+func (self v3Groups) buildResource(n string, g *Attribute) interface{} {
+	if g.Group != nil {
+		return &v3Group{
+			Name:  n,
+			Id:    g.Id,
+			Users: g.Users,
+		}
+	}
+	return nil
+}
+
+func (self v3Sudoers) buildResource(n string, u *Attribute) interface{} {
+	if u.User != nil {
+		return &v3Sudo{
+			Name:     n,
+			Password: u.Password,
+		}
+	}
+	return nil
+}
+
+func (self *v3_ResponseFormat) Response() {
+	if len(self.Items) == 0 {
+		rest.NotFound(self.w, self.r)
+		return
+	}
+
+	self.w.Header().Set("X-STNS-MIN-ID", strconv.Itoa(self.query.GetMinId()))
+
+	resource := NewV3Resource(self.query)
+	resources := []interface{}{}
+
+	for n, u := range self.Items {
+		resources = append(resources, resource.buildResource(n, u))
+		if self.query.column != "list" {
+			break
+		}
+	}
+
+	if len(resources) > 0 {
+		if self.query.column == "list" {
+			self.w.WriteJson(resources)
+		} else {
+			self.w.WriteJson(resources[0])
+		}
+	} else {
+		rest.NotFound(self.w, self.r)
+	}
+}
+
+func NewResponder(q *Query, w rest.ResponseWriter, r *rest.Request) responser {
+	res := q.Get()
+	switch r.URL.Path[1:3] {
+	case "v2":
+		return &v2_ResponseFormat{
+			Items: res,
+			query: q,
+			w:     w,
+			r:     r,
+		}
+	case "v3":
+		return &v3_ResponseFormat{
+			Items: res,
+			query: q,
+			w:     w,
+			r:     r,
+		}
+	default:
+		return &v1_ResponseFormat{
+			Items: res,
+			query: q,
+			w:     w,
+			r:     r,
+		}
+	}
+}

--- a/stns/responder.go
+++ b/stns/responder.go
@@ -35,8 +35,8 @@ func (self *v1_ResponseFormat) Response() {
 // ----------------------------------------
 type v2_MetaData struct {
 	ApiVersion float64 `json:"api_version"`
-	Result     string  `json:"result""`
-	MinId      int     `json:"min_id""`
+	Result     string  `json:"result"`
+	MinId      int     `json:"min_id"`
 }
 
 type v2_ResponseFormat struct {

--- a/stns/stns.go
+++ b/stns/stns.go
@@ -112,6 +112,8 @@ func (s *Stns) NewApiHandler() http.Handler {
 	h := Handler{&s.config}
 
 	router, err := rest.MakeRouter(
+		rest.Get("/v3/:resource_name/list", h.GetList),
+		rest.Get("/v3/:resource_name/:column/:value", h.Get),
 		rest.Get("/v2/:resource_name/list", h.GetList),
 		rest.Get("/v2/:resource_name/:column/:value", h.Get),
 		rest.Get("/:resource_name/list", h.GetList),

--- a/stns/stns_test.go
+++ b/stns/stns_test.go
@@ -28,6 +28,11 @@ func TestHandlerV1User(t *testing.T) {
 	recorded.BodyIs(`{"example":{"id":1000,"password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"],"link_users":null}}`)
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/user/id/1001", nil))
 	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/user/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"example":{"id":1000,"password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"],"link_users":null}}`)
 }
 
 func TestHandlerV1Group(t *testing.T) {
@@ -49,6 +54,11 @@ func TestHandlerV1Group(t *testing.T) {
 
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/group/id/3001", nil))
 	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/group/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"example_group":{"id":3000,"users":["example"],"link_groups":null}}`)
 }
 
 func TestHandlerV1Sudo(t *testing.T) {
@@ -65,6 +75,11 @@ func TestHandlerV1Sudo(t *testing.T) {
 
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/sudo/id/1001", nil))
 	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/sudo/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"example_sudo":{"id":0,"password":"p@ssword","group_id":0,"directory":"","shell":"","gecos":"","keys":null,"link_users":null}}`)
 }
 
 func TestHandlerV2User(t *testing.T) {
@@ -85,7 +100,13 @@ func TestHandlerV2User(t *testing.T) {
 	recorded.BodyIs(`{"metadata":{"api_version":2.1,"result":"success","min_id":1000},"items":{"example":{"id":1000,"password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"],"link_users":null}}}`)
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/user/id/1001", nil))
 	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/user/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"metadata":{"api_version":2.1,"result":"success","min_id":1000},"items":{"example":{"id":1000,"password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"],"link_users":null}}}`)
 }
+
 func TestHandlerV2Group(t *testing.T) {
 	config, _ := LoadConfig("./fixtures/stns_01.conf")
 	s := Create(config, "", "", false)
@@ -105,7 +126,13 @@ func TestHandlerV2Group(t *testing.T) {
 
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/group/id/3001", nil))
 	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/group/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"metadata":{"api_version":2.1,"result":"success","min_id":3000},"items":{"example_group":{"id":3000,"users":["example"],"link_groups":null}}}`)
 }
+
 func TestHandlerV2Sudo(t *testing.T) {
 	config, _ := LoadConfig("./fixtures/stns_01.conf")
 	s := Create(config, "", "", false)
@@ -122,7 +149,93 @@ func TestHandlerV2Sudo(t *testing.T) {
 	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/sudo/id/1001", nil))
 	recorded.CodeIs(404)
 
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v2/sudo/list", nil))
+	recorded.CodeIs(200)
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"metadata":{"api_version":2.1,"result":"success","min_id":0},"items":{"example_sudo":{"id":0,"password":"p@ssword","group_id":0,"directory":"","shell":"","gecos":"","keys":null,"link_users":null}}}`)
 }
+
+func TestHandlerV3User(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "", false)
+	s.SetMiddleWare(rest.DefaultCommonStack)
+
+	recorded := test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/user/name/example", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "1000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"id":1000,"name":"example","password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"]}`)
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/user/name/example3", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/user/id/1000", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "1000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"id":1000,"name":"example","password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"]}`)
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/user/id/1001", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/user/list", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "1000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`[{"id":1000,"name":"example","password":"p@ssword","group_id":2000,"directory":"/home/example","shell":"/bin/bash","gecos":"","keys":["ssh-rsa aaa"]}]`)
+}
+
+func TestHandlerv3Group(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "", false)
+	s.SetMiddleWare(rest.DefaultCommonStack)
+
+	recorded := test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/group/name/example_group", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "3000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"id":3000,"name":"example_group","users":["example"]}`)
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/group/name/example_group3", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/group/id/3000", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "3000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"id":3000,"name":"example_group","users":["example"]}`)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/group/id/3001", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/group/list", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "3000")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`[{"id":3000,"name":"example_group","users":["example"]}]`)
+}
+
+func TestHandlerv3Sudo(t *testing.T) {
+	config, _ := LoadConfig("./fixtures/stns_01.conf")
+	s := Create(config, "", "", false)
+	s.SetMiddleWare(rest.DefaultCommonStack)
+
+	recorded := test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/sudo/name/example_sudo", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "0")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`{"name":"example_sudo","password":"p@ssword"}`)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/sudo/name/example_notfound", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/sudo/id/1001", nil))
+	recorded.CodeIs(404)
+
+	recorded = test.RunRequest(t, s.NewApiHandler(), test.MakeSimpleRequest("GET", "http://localhost:9999/v3/sudo/list", nil))
+	recorded.CodeIs(200)
+	recorded.HeaderIs("X-STNS-MIN-ID", "0")
+	recorded.ContentTypeIsJson()
+	recorded.BodyIs(`[{"name":"example_sudo","password":"p@ssword"}]`)
+}
+
 func TestBasicAuth(t *testing.T) {
 	config, _ := LoadConfig("./fixtures/stns_02.conf")
 	s := Create(config, "", "", false)


### PR DESCRIPTION
ref: http://qiita.com/sawanoboly/items/5113cb116eaef4d105cf

@sawanoboly さんの上記の記事を拝見し、レスポンスフォーマットを変えたほうがよりバックエンドの実装が平易になるであろうと判断したので、V3 Apiを追加しました。

- name
```
% curl -i http://localhost:1104/v3/user/name/test1
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
X-Powered-By: go-json-rest
X-Stns-Min-Id: 1
Date: Thu, 10 Nov 2016 17:18:38 GMT
Content-Length: 151

{
  "id": 2,
  "name": "test1",
  "password": "",
  "group_id": 2,
  "directory": "/home/test",
  "shell": "/bin/bash",
  "gecos": "",
  "keys": null
}
```

- list
```
curl -i http://localhost:1104/v3/user/list
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
X-Powered-By: go-json-rest
X-Stns-Min-Id: 1
Date: Thu, 10 Nov 2016 17:19:14 GMT
Content-Length: 524

[
  {
    "id": 1,
    "name": "test",
    "password": "",
    "group_id": 1,
    "directory": "/home/test",
    "shell": "/bin/bash",
    "gecos": "",
    "keys": null
  },
  {
    "id": 2,
    "name": "test1",
    "password": "",
    "group_id": 2,
    "directory": "/home/test",
    "shell": "/bin/bash",
    "gecos": "",
    "keys": null
  },
  {
    "id": 2,
    "name": "test5",
    "password": "test",
    "group_id": 2,
    "directory": "/home/test",
    "shell": "/bin/bash",
    "gecos": "",
    "keys": null
  }
]
```

## v2からの主な変更点
- Metadataを撤去
- 最小のIDであるMinIDをヘッダへ移動
- name属性の階層を一段下げてフラットな形式にした
- listの結果のみを配列にした
- link_usersなどの不要なカラムの出力を抑制した

## その他
- v1,v2下位互換あり
