### PR TITLE
Duplicate id is not allowed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
 - golint ./...
 - bundle exec rake test_pkg
 go:
-  - 1.7.1
+  - 1.7.4

--- a/stns/config_test.go
+++ b/stns/config_test.go
@@ -1,6 +1,7 @@
 package stns
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,13 @@ func TestMinID(t *testing.T) {
 	assert(t, minUserID == 1, "unmatch min user")
 	assert(t, minGroupID == 3, "unmatch min group")
 }
+
+func TestDuplicateID(t *testing.T) {
+	_, err := LoadConfig("./fixtures/duplicate_id.conf")
+	fmt.Println(err)
+	assert(t, err.Error() == "Duplicate id is not allowed user_id:1001", "TestDuplicateID")
+}
+
 func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Error(err)

--- a/stns/fixtures/duplicate_id.conf
+++ b/stns/fixtures/duplicate_id.conf
@@ -1,0 +1,5 @@
+[users.example1]
+id = 1001
+
+[users.example2]
+id = 1001


### PR DESCRIPTION
user_id, group_idが重複した場合、誤った名前解決など、想定しない動作を起こすことが想定されるためSTNSで重複チェックを行います。