### PR TITLE
example uid was duplicated.

### DIFF
--- a/example/files/stns.conf
+++ b/example/files/stns.conf
@@ -13,6 +13,6 @@ id = 1001
 users = ["example"]
 
 [users.example1]
-id = 1001
+id = 1002
 group_id = 1001
 #keys = ["ssh xxxxxxx"]


### PR DESCRIPTION
The example users' uid was duplicated and fixed.