### PR TITLE
余計なクエリを投げないために、max,minのIDはメモリに保持する

### DIFF
--- a/libnss/stns.c
+++ b/libnss/stns.c
@@ -90,7 +90,7 @@ static void trim(char *s)
 #define SET_TRIM_ID(high_or_low, user_or_group)                                                                        \
   tp = strtok(NULL, ".");                                                                                              \
   trim(tp);                                                                                                            \
-  set_##high_or_low##est_##user_or_group##_id(atoi(tp));
+  set_##user_or_group##_##high_or_low##est_id(atoi(tp));
 
 static size_t header_callback(char *buffer, size_t size, size_t nitems, void *userdata)
 {

--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -61,6 +61,11 @@ extern int stns_user_lowest_query_available(int);
 extern int stns_group_highest_query_available(int);
 extern int stns_group_lowest_query_available(int);
 
+extern void set_highest_user_id(int);
+extern void set_lowest_user_id(int);
+extern void set_highest_group_id(int);
+extern void set_lowest_group_id(int);
+
 #define STNS_ENSURE_BY(method_key, key_type, key_name, json_type, json_key, match_method, resource, ltype)             \
   enum nss_status ensure_##resource##_by_##method_key(char *data, stns_conf_t *c, key_type key_name,                   \
                                                       struct resource *rbuf, char *buf, size_t buflen, int *errnop)    \
@@ -221,14 +226,6 @@ extern int stns_group_lowest_query_available(int);
     return inner_nss_stns_get##type##ent_r(&c, rbuf, buf, buflen, errnop);                                             \
   }
 
-#define USER_ID_QUERY_AVAILABLE                                                                                        \
-  if (!stns_user_highest_query_available(uid) || !stns_user_lowest_query_available(uid))                               \
-    return NSS_STATUS_NOTFOUND;
-
-#define GROUP_ID_QUERY_AVAILABLE                                                                                       \
-  if (!stns_group_highest_query_available(gid) || !stns_group_lowest_query_available(gid))                             \
-    return NSS_STATUS_NOTFOUND;
-
 #define SET_GET_HIGH_LOW_ID(highest_or_lowest, user_or_group)                                                          \
   void set_##highest_or_lowest##_##user_or_group##_id(int id)                                                          \
   {                                                                                                                    \
@@ -262,4 +259,13 @@ extern int stns_group_lowest_query_available(int);
       return 0;                                                                                                        \
     return 1;                                                                                                          \
   }
+
+#define USER_ID_QUERY_AVAILABLE                                                                                        \
+  if (!stns_user_highest_query_available(uid) || !stns_user_lowest_query_available(uid))                               \
+    return NSS_STATUS_NOTFOUND;
+
+#define GROUP_ID_QUERY_AVAILABLE                                                                                       \
+  if (!stns_group_highest_query_available(gid) || !stns_group_lowest_query_available(gid))                             \
+    return NSS_STATUS_NOTFOUND;
+
 #endif /* STNS_H */

--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -18,7 +18,7 @@
 #include <pthread.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
+#include <ctype.h>
 #define STNS_VERSION "2.0.0"
 #define STNS_VERSION_WITH_NAME "stns/" STNS_VERSION
 // 10MB

--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -56,6 +56,10 @@ extern int stns_request(stns_conf_t *, char *, stns_http_response_t *);
 extern int stns_request_available(char *, stns_conf_t *);
 extern void stns_make_lockfile(char *);
 extern int stns_exec_cmd(char *, char *, char *);
+extern int stns_user_highest_query_available(int);
+extern int stns_user_lowest_query_available(int);
+extern int stns_group_highest_query_available(int);
+extern int stns_group_lowest_query_available(int);
 
 #define STNS_ENSURE_BY(method_key, key_type, key_name, json_type, json_key, match_method, resource, ltype)             \
   enum nss_status ensure_##resource##_by_##method_key(char *data, stns_conf_t *c, key_type key_name,                   \
@@ -217,17 +221,12 @@ extern int stns_exec_cmd(char *, char *, char *);
     return inner_nss_stns_get##type##ent_r(&c, rbuf, buf, buflen, errnop);                                             \
   }
 
-extern int user_highest_query_available(int);
-extern int user_lowest_query_available(int);
-extern int group_highest_query_available(int);
-extern int group_lowest_query_available(int);
-
 #define USER_ID_QUERY_AVAILABLE                                                                                        \
-  if (!user_highest_query_available(uid) || !user_lowest_query_available(uid))                                         \
+  if (!stns_user_highest_query_available(uid) || !stns_user_lowest_query_available(uid))                               \
     return NSS_STATUS_NOTFOUND;
 
 #define GROUP_ID_QUERY_AVAILABLE                                                                                       \
-  if (!group_highest_query_available(gid) || !group_lowest_query_available(gid))                                       \
+  if (!stns_group_highest_query_available(gid) || !stns_group_lowest_query_available(gid))                             \
     return NSS_STATUS_NOTFOUND;
 
 #define SET_GET_HIGH_LOW_ID(highest_or_lowest, user_or_group)                                                          \
@@ -256,7 +255,7 @@ extern int group_lowest_query_available(int);
   }
 
 #define ID_QUERY_AVAILABLE(user_or_group, high_or_low, inequality)                                                     \
-  int user_or_group##_##high_or_low##est_query_available(int id)                                                       \
+  int stns_##user_or_group##_##high_or_low##est_query_available(int id)                                                \
   {                                                                                                                    \
     int r = get_##high_or_low##est_##user_or_group##_id();                                                             \
     if (r != 0 && r inequality id)                                                                                     \

--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -233,7 +233,7 @@ extern void set_group_lowest_id(int);
     highest_or_lowest##_##user_or_group##_id = id;                                                                     \
     pthread_mutex_unlock(&user_or_group##_mutex);                                                                      \
   }                                                                                                                    \
-  int get_##user_or_group##_##highest_or_lowest##_id()                                                                 \
+  int get_##user_or_group##_##highest_or_lowest##_id(void)                                                             \
   {                                                                                                                    \
     int r;                                                                                                             \
     pthread_mutex_lock(&user_or_group##_mutex);                                                                        \

--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -61,10 +61,10 @@ extern int stns_user_lowest_query_available(int);
 extern int stns_group_highest_query_available(int);
 extern int stns_group_lowest_query_available(int);
 
-extern void set_highest_user_id(int);
-extern void set_lowest_user_id(int);
-extern void set_highest_group_id(int);
-extern void set_lowest_group_id(int);
+extern void set_user_highest_id(int);
+extern void set_user_lowest_id(int);
+extern void set_group_highest_id(int);
+extern void set_group_lowest_id(int);
 
 #define STNS_ENSURE_BY(method_key, key_type, key_name, json_type, json_key, match_method, resource, ltype)             \
   enum nss_status ensure_##resource##_by_##method_key(char *data, stns_conf_t *c, key_type key_name,                   \
@@ -227,13 +227,13 @@ extern void set_lowest_group_id(int);
   }
 
 #define SET_GET_HIGH_LOW_ID(highest_or_lowest, user_or_group)                                                          \
-  void set_##highest_or_lowest##_##user_or_group##_id(int id)                                                          \
+  void set_##user_or_group##_##highest_or_lowest##_id(int id)                                                          \
   {                                                                                                                    \
     pthread_mutex_lock(&user_or_group##_mutex);                                                                        \
     highest_or_lowest##_##user_or_group##_id = id;                                                                     \
     pthread_mutex_unlock(&user_or_group##_mutex);                                                                      \
   }                                                                                                                    \
-  int get_##highest_or_lowest##_##user_or_group##_id()                                                                 \
+  int get_##user_or_group##_##highest_or_lowest##_id()                                                                 \
   {                                                                                                                    \
     int r;                                                                                                             \
     pthread_mutex_lock(&user_or_group##_mutex);                                                                        \
@@ -254,7 +254,7 @@ extern void set_lowest_group_id(int);
 #define ID_QUERY_AVAILABLE(user_or_group, high_or_low, inequality)                                                     \
   int stns_##user_or_group##_##high_or_low##est_query_available(int id)                                                \
   {                                                                                                                    \
-    int r = get_##high_or_low##est_##user_or_group##_id();                                                             \
+    int r = get_##user_or_group##_##high_or_low##est_id();                                                             \
     if (r != 0 && r inequality id)                                                                                     \
       return 0;                                                                                                        \
     return 1;                                                                                                          \

--- a/libnss/stns_group.c
+++ b/libnss/stns_group.c
@@ -34,6 +34,6 @@ static int entry_idx   = 0;
 STNS_ENSURE_BY(name, const char *, group_name, string, name, (strcmp(current, group_name) == 0), group, GROUP)
 STNS_ENSURE_BY(gid, gid_t, gid, integer, id, current == gid, group, GROUP)
 
-STNS_GET_SINGLE_VALUE_METHOD(getgrnam_r, const char *name, "groups?name=%s", name, group)
-STNS_GET_SINGLE_VALUE_METHOD(getgrgid_r, gid_t gid, "groups?id=%d", gid, group)
+STNS_GET_SINGLE_VALUE_METHOD(getgrnam_r, const char *name, "groups?name=%s", name, group, )
+STNS_GET_SINGLE_VALUE_METHOD(getgrgid_r, gid_t gid, "groups?id=%d", gid, group, GROUP_ID_QUERY_AVAILABLE)
 STNS_SET_ENTRIES(gr, GROUP, group, groups)

--- a/libnss/stns_passwd.c
+++ b/libnss/stns_passwd.c
@@ -27,6 +27,6 @@ static int entry_idx   = 0;
 STNS_ENSURE_BY(name, const char *, user_name, string, name, (strcmp(current, user_name) == 0), passwd, PASSWD)
 STNS_ENSURE_BY(uid, uid_t, uid, integer, id, current == uid, passwd, PASSWD)
 
-STNS_GET_SINGLE_VALUE_METHOD(getpwnam_r, const char *name, "users?name=%s", name, passwd)
-STNS_GET_SINGLE_VALUE_METHOD(getpwuid_r, uid_t uid, "users?id=%d", uid, passwd)
+STNS_GET_SINGLE_VALUE_METHOD(getpwnam_r, const char *name, "users?name=%s", name, passwd, )
+STNS_GET_SINGLE_VALUE_METHOD(getpwuid_r, uid_t uid, "users?id=%d", uid, passwd, USER_ID_QUERY_AVAILABLE)
 STNS_SET_ENTRIES(pw, PASSWD, passwd, users)

--- a/libnss/stns_shadow.c
+++ b/libnss/stns_shadow.c
@@ -19,6 +19,6 @@ static int entry_idx   = 0;
 
 STNS_ENSURE_BY(name, const char *, user_name, string, name, (strcmp(current, user_name) == 0), spwd, SHADOW)
 STNS_ENSURE_BY(uid, uid_t, uid, integer, id, current == uid, spwd, SHADOW)
-STNS_GET_SINGLE_VALUE_METHOD(getspnam_r, const char *name, "users?name=%s", name, spwd)
-STNS_GET_SINGLE_VALUE_METHOD(getspuid_r, uid_t uid, "users?id=%d", uid, spwd)
+STNS_GET_SINGLE_VALUE_METHOD(getspnam_r, const char *name, "users?name=%s", name, spwd, )
+STNS_GET_SINGLE_VALUE_METHOD(getspuid_r, uid_t uid, "users?id=%d", uid, spwd, )
 STNS_SET_ENTRIES(sp, SHADOW, spwd, users)

--- a/libnss/stns_test.c
+++ b/libnss/stns_test.c
@@ -123,3 +123,20 @@ Test(stns_exec_cmd, ok)
   cr_expect_str_eq(result, "aaabbbccc\nddd\n");
   free(result);
 }
+
+Test(query_available, ok)
+{
+  set_highest_user_id(10);
+  set_lowest_user_id(3);
+  set_highest_group_id(10);
+  set_lowest_group_id(3);
+
+  cr_assert_eq(stns_user_highest_query_available(1), 1);
+  cr_assert_eq(stns_user_highest_query_available(11), 0);
+  cr_assert_eq(stns_user_lowest_query_available(4), 1);
+  cr_assert_eq(stns_user_lowest_query_available(2), 0);
+  cr_assert_eq(stns_group_highest_query_available(1), 1);
+  cr_assert_eq(stns_group_highest_query_available(11), 0);
+  cr_assert_eq(stns_group_lowest_query_available(4), 1);
+  cr_assert_eq(stns_group_lowest_query_available(2), 0);
+}

--- a/libnss/stns_test.c
+++ b/libnss/stns_test.c
@@ -126,15 +126,16 @@ Test(stns_exec_cmd, ok)
 
 Test(query_available, ok)
 {
-  set_highest_user_id(10);
-  set_lowest_user_id(3);
-  set_highest_group_id(10);
-  set_lowest_group_id(3);
+  set_user_highest_id(10);
+  set_user_lowest_id(3);
+  set_group_highest_id(10);
+  set_group_lowest_id(3);
 
   cr_assert_eq(stns_user_highest_query_available(1), 1);
   cr_assert_eq(stns_user_highest_query_available(11), 0);
   cr_assert_eq(stns_user_lowest_query_available(4), 1);
   cr_assert_eq(stns_user_lowest_query_available(2), 0);
+
   cr_assert_eq(stns_group_highest_query_available(1), 1);
   cr_assert_eq(stns_group_highest_query_available(11), 0);
   cr_assert_eq(stns_group_lowest_query_available(4), 1);


### PR DESCRIPTION
ミドルウェアユーザーのインストール時などに存在するuidをすべて確認する挙動があり、ユーザー追加が律速になるので、明確に存在しないユーザーの場合はクエリを投げないようにする。