### PR TITLE
json_value_freeがsegvすることがある

### DIFF
--- a/libnss/stns.h
+++ b/libnss/stns.h
@@ -158,6 +158,8 @@ extern void set_group_lowest_id(int);
   {                                                                                                                    \
     pthread_mutex_lock(&type##ent_mutex);                                                                              \
                                                                                                                        \
+    entries          = NULL;                                                                                           \
+    entry_idx        = 0;                                                                                              \
     JSON_Value *root = json_parse_string(data);                                                                        \
     if (root == NULL) {                                                                                                \
       free(data);                                                                                                      \
@@ -166,8 +168,7 @@ extern void set_group_lowest_id(int);
       return NSS_STATUS_UNAVAIL;                                                                                       \
     }                                                                                                                  \
                                                                                                                        \
-    entries   = root;                                                                                                  \
-    entry_idx = 0;                                                                                                     \
+    entries = root;                                                                                                    \
                                                                                                                        \
     pthread_mutex_unlock(&type##ent_mutex);                                                                            \
     return NSS_STATUS_SUCCESS;                                                                                         \


### PR DESCRIPTION
```
$ sudo su
*** Error in `sudo': free(): invalid pointer: 0x000056209c59e430 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7ff0fe2067e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7ff0fe20f37a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7ff0fe21353c]
/usr/lib/x86_64-linux-gnu/libnss_stns.so.2(json_value_free+0x72)[0x7ff0fcc90c4b]
/usr/lib/x86_64-linux-gnu/libnss_stns.so.2(+0xa050)[0x7ff0fcc8e050]
/usr/lib/x86_64-linux-gnu/libnss_stns.so.2(json_value_free+0x61)[0x7ff0fcc90c3a]
/usr/lib/x86_64-linux-gnu/libnss_stns.so.2(_nss_stns_endgrent+0x2c)[0x7ff0fcc984ae]
/lib/x86_64-linux-gnu/libc.so.6(+0x12a5c9)[0x7ff0fe2b95c9]
/lib/x86_64-linux-gnu/libc.so.6(endgrent+0x7c)[0x7ff0fe258e5c]
/usr/lib/sudo/sudoers.so(+0x2d5ba)[0x7ff0f81b25ba]
/usr/lib/sudo/sudoers.so(+0x1a4b7)[0x7ff0f819f4b7]
/usr/lib/sudo/sudoers.so(+0x1494f)[0x7ff0f819994f]
sudo(+0x4f3f)[0x56209bd19f3f]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7ff0fe1af830]
sudo(+0x6859)[0x56209bd1b859]
======= Memory map: ========
```

json_value_freeコール時に、対象はグローバル変数なのだが、毎回明示的に初期化していないのでfree時に値がおかしくなっている時がある。