### PR TITLE
FIX should shutdown when STNS recived signals

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -33,7 +33,7 @@ override_dh_auto_install:
 	dh_auto_install -- PREFIX=$(PREFIX) BINDIR=$(BINDIR)
 	install -pm 644 package/stns-v2.conf $(CONFDIR)/stns/server/stns.conf
 	install -pm 644 package/stns-v2.logrotate $(CONFDIR)/logrotate.d/stns
-	install -pm 755 package/stns-v2.systemd $(CONFDIR)/systemd/system/stns.service
+	install -pm 644 package/stns-v2.systemd $(CONFDIR)/systemd/system/stns.service
 	install -pm 755 package/stns-v2.sysv $(CONFDIR)/init.d/stns
 	find $(DESTDIR)
 override_dh_usrlocal:

--- a/rpm/stns.spec
+++ b/rpm/stns.spec
@@ -48,7 +48,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/init.d
 install -m 755 package/stns-v2.initd  %{buildroot}%{_sysconfdir}/init.d/stns
 %else
 mkdir -p %{buildroot}%{_sysconfdir}/systemd/system/
-install -m 755 package/stns-v2.systemd %{buildroot}%{_sysconfdir}/systemd/system/stns.service
+install -m 644 package/stns-v2.systemd %{buildroot}%{_sysconfdir}/systemd/system/stns.service
 %endif
 
 mkdir -p %{buildroot}%{_sysconfdir}/logrotate.d


### PR DESCRIPTION
I reaized that STNS can't shutdown when I exec command `service stns shutdown`.
therefore, I fixed it.