### PR TITLE
Fix auto-merge workflow repository condition

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'owner/my_repo'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'STNS/STNS'
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary

- auto_merge.yml のリポジトリ条件 owner/my_repo がプレースホルダーのままになっていたため、STNS/STNS に修正
- これにより、Dependabot によるパッチリリースの PR が CI を通過した際に自動マージされるようになる